### PR TITLE
formatObject also returns the result when there is just warnings

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,8 +27,6 @@ const flatten = (r, n) => {
 };
 
 const formatObject = (r, startPath) => {
-  if (r.ok) return;
-
   const fl = flatten(r, startPath);
 
   const rr = { errors: [], warnings: [] };

--- a/test.js
+++ b/test.js
@@ -105,6 +105,25 @@ test('object merge', t => {
   t.falsy(mergedSchema({ a: true, c: 'yo', b: { y: false, z: 3 } }).ok);
 });
 
+test('warnings', t => {
+  const schema = v.object({
+    a: v.bool,
+    b: v.deprecated(v.string, 'moved to `c`'),
+    files: v.objects({ keys: ['javascripts', 'stylesheets'] }, v.bool)
+  });
+
+  const result = schema({ a: true, b: 'string', files: { javascript: true } });
+  const fmt = skemata.formatObject(result, 'config');
+
+  t.deepEqual(fmt, {
+    errors: [],
+    warnings: [
+      { path: 'config.b', warning: 'deprecated: moved to `c`' },
+      { path: 'config.files.javascript', warning: 'unrecognized key: javascript; expected either of javascripts, stylesheets; perhaps you meant javascripts' }
+    ]
+  });
+});
+
 test('errors and warnings', t => {
   const schema = v.object({
     a: v.bool,


### PR DESCRIPTION
Right now, if the config has just warnings, the user won't know. I think that make sense to notify the user when there is also just warnings. What do you think?
